### PR TITLE
Add FFI functions for hybrid sync

### DIFF
--- a/include/zeos-caterpillar.h
+++ b/include/zeos-caterpillar.h
@@ -38,7 +38,9 @@ extern bool wallet_transaction_history_json(wallet_t* p_wallet, bool pretty, con
 extern bool wallet_addresses_json(wallet_t* p_wallet, bool pretty, const char** out_json);
 extern bool wallet_derive_address(wallet_t* p_wallet, const char** out_address);
 extern bool wallet_add_leaves(wallet_t* p_wallet, const char* leaves);
-extern bool wallet_add_notes(wallet_t* p_wallet, const char* notes);
+extern uint64_t wallet_add_notes(wallet_t* p_wallet, const char* notes, uint32_t block_num, uint64_t block_ts);
+extern bool wallet_set_block_num(wallet_t* p_wallet, uint32_t block_num);
+extern bool wallet_add_nullifiers(wallet_t* p_wallet, const char* nullifiers_hex, uint64_t* out_count);
 extern bool wallet_add_unpublished_notes(wallet_t* p_wallet, const char* unpublished_notes);
 extern bool wallet_create_unpublished_auth_note(wallet_t* p_wallet, const char* seed, uint64_t contract, const char* address, const char** out_unpublished_notes);
 extern bool wallet_resolve(wallet_t* p_wallet, const char* ztx_json, const char* fee_token_contract_json, const char* fees_json, const char** out_rztx_json);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1339,14 +1339,16 @@ pub extern "C" fn wallet_add_leaves(
 pub extern "C" fn wallet_add_notes(
     p_wallet: *mut Wallet,
     notes: *const libc::c_char,
-) -> bool {
+    block_num: u32,
+    block_ts: u64,
+) -> u64 {
     if p_wallet.is_null() {
         set_last_error("wallet_add_notes: p_wallet is null");
-        return false;
+        return 0;
     }
     if notes.is_null() {
         set_last_error("wallet_add_notes: notes is null");
-        return false;
+        return 0;
     }
 
     let wallet = unsafe { &mut *p_wallet };
@@ -1354,18 +1356,84 @@ pub extern "C" fn wallet_add_notes(
         Ok(s) => s,
         Err(_) => {
             set_last_error("wallet_add_notes: invalid UTF-8 in notes");
-            return false;
+            return 0;
         }
     };
     let notes_vec: Vec<String> = match serde_json::from_str(notes_str) {
         Ok(v) => v,
         Err(e) => {
             set_last_error(&format!("wallet_add_notes: invalid JSON in notes: {e}"));
+            return 0;
+        }
+    };
+
+    wallet.add_notes(&notes_vec, block_num, block_ts)
+}
+
+#[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
+#[no_mangle]
+pub extern "C" fn wallet_set_block_num(
+    p_wallet: *mut Wallet,
+    block_num: u32,
+) -> bool {
+    if p_wallet.is_null() {
+        set_last_error("wallet_set_block_num: p_wallet is null");
+        return false;
+    }
+    let wallet = unsafe { &mut *p_wallet };
+    wallet.set_block_num(block_num);
+    true
+}
+
+#[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
+#[no_mangle]
+pub extern "C" fn wallet_add_nullifiers(
+    p_wallet: *mut Wallet,
+    nullifiers_hex: *const libc::c_char,
+    out_count: *mut u64,
+) -> bool {
+    if p_wallet.is_null() {
+        set_last_error("wallet_add_nullifiers: p_wallet is null");
+        return false;
+    }
+    if nullifiers_hex.is_null() {
+        set_last_error("wallet_add_nullifiers: nullifiers_hex is null");
+        return false;
+    }
+
+    let wallet = unsafe { &mut *p_wallet };
+    let hex_str: &str = match unsafe { std::ffi::CStr::from_ptr(nullifiers_hex) }.to_str() {
+        Ok(s) => s,
+        Err(_) => {
+            set_last_error("wallet_add_nullifiers: invalid UTF-8");
             return false;
         }
     };
 
-    wallet.add_notes(&notes_vec, 0, 0);
+    use crate::contract::ScalarBytes;
+    let mut nullifiers: Vec<ScalarBytes> = Vec::new();
+    let bytes_str = hex_str.as_bytes();
+    let mut i = 0;
+    while i + 64 <= bytes_str.len() {
+        let chunk = &hex_str[i..i+64];
+        let mut arr = [0u8; 32];
+        for j in 0..32 {
+            arr[j] = match u8::from_str_radix(&chunk[j*2..j*2+2], 16) {
+                Ok(b) => b,
+                Err(_) => {
+                    set_last_error("wallet_add_nullifiers: invalid hex");
+                    return false;
+                }
+            };
+        }
+        nullifiers.push(ScalarBytes(arr));
+        i += 64;
+    }
+
+    let count = wallet.mark_notes_spent(&nullifiers);
+    if !out_count.is_null() {
+        unsafe { *out_count = count as u64; }
+    }
     true
 }
 

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -342,6 +342,11 @@ impl Wallet
         self.block_num
     }
 
+    pub fn set_block_num(&mut self, bn: u32)
+    {
+        self.block_num = bn;
+    }
+
     pub fn leaf_count(&self) -> u64
     {
         self.leaf_count
@@ -931,6 +936,41 @@ impl Wallet
 
         self.leaf_count += 1;
         return tos;
+    }
+
+    pub fn mark_notes_spent(&mut self, nullifiers: &[ScalarBytes]) -> usize
+    {
+        if nullifiers.is_empty() || self.unspent_notes.is_empty() {
+            return 0;
+        }
+
+        let fvk = if !self.seed.is_empty() {
+            let sk = SpendingKey::from_seed(&self.seed);
+            FullViewingKey::from_spending_key(&sk)
+        } else {
+            return 0;
+        };
+        let mut spent_count = 0;
+
+        let nf_scalars: Vec<crate::engine::Scalar> = nullifiers.iter()
+            .filter_map(|nf| {
+                crate::engine::Scalar::try_from(nf.clone()).ok()
+            })
+            .collect();
+
+        let mut i = self.unspent_notes.len();
+        while i > 0 {
+            i -= 1;
+            if self.unspent_notes[i].note().is_auth_token() { continue; }
+            let note_nf = self.unspent_notes[i].note().nullifier(&fvk.nk, self.unspent_notes[i].position()).extract().0;
+            if nf_scalars.iter().any(|nf| note_nf.eq(nf)) {
+                let note = self.unspent_notes.remove(i);
+                self.spent_notes.push(note);
+                spent_count += 1;
+            }
+        }
+
+        spent_count
     }
 
     pub fn get_sister_path_and_root(&self, note: &NoteEx) -> Option<(Vec<Option<([u8; 32], bool)>>, ScalarBytes)>


### PR DESCRIPTION
## Summary

Adds three FFI functions needed by the hybrid sync feature in [zeos-wallet#1](https://github.com/mschoenebeck/zeos-wallet/pull/1):

- **`wallet_add_notes`** — extended signature: takes `block_num` and `block_ts`, returns packed `u64` with decrypted note counts (`ats<<16 | nfts<<8 | fts`) instead of `bool`
- **`wallet_set_block_num`** — sets block number directly (Hyperion path bypasses `wallet_digest_block`)
- **`wallet_add_nullifiers`** — takes hex-encoded nullifiers from the on-chain table, marks matching unspent notes as spent

Also adds `mark_notes_spent()` and `set_block_num()` methods to `Wallet`.

## Why

The hybrid sync fetches historic actions from Hyperion v2 instead of calling `get_block` per block. This requires:
1. Feeding note ciphertexts directly via `wallet_add_notes` with block context
2. Persisting block progress without going through `wallet_digest_block`
3. Scanning the nullifiers table to mark spent notes (since Hyperion doesn't process nullifiers inline)

## Test plan

- [x] `cargo check` passes
- [x] Full integration tested with hybrid sync on Telos mainnet (168 FT, 40 AT decrypted from 2000 actions, 397 notes marked spent)